### PR TITLE
Update rundeck gem, stop using build-essential/libxml packages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rake'
 gem 'test-kitchen'
 gem 'kitchen-vagrant'
 
-gem 'rundeck'
+gem 'rundeck', '>= 1.1.0'
 
 platforms :mri_19 do
   gem 'ohai', '~> 7.4.0'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -107,6 +107,3 @@ default['rundeck_server']['rundeck-config.framework']['framework.libext.dir']   
 default['rundeck_server']['rundeck-config.framework']['framework.ssh.keypath']      = '/var/lib/rundeck/.ssh/id_rsa'
 default['rundeck_server']['rundeck-config.framework']['framework.ssh.user']         = 'rundeck'
 default['rundeck_server']['rundeck-config.framework']['framework.ssh.timeout']      = 0
-
-default['build-essential']['compile_time'] = true
-default['libxml2']['compile_time'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,8 +8,6 @@ version          '0.2.0'
 
 depends          'yum'
 depends          'java'
-depends          'build-essential'
-depends          'libxml2'
 
 suggests         'rundeck-bridge'
 suggests         'rundeck-node'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,9 +11,7 @@ service 'rundeckd' do
   action   [:enable, :start]
 end
 
-# Install build essential at compile time for gem compilation
-include_recipe 'build-essential'
-include_recipe 'libxml2'
-
 # Install rundeck gem for API communication
-chef_gem 'rundeck'
+chef_gem 'rundeck' do
+  version '> 1.0.2'
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -13,5 +13,5 @@ end
 
 # Install rundeck gem for API communication
 chef_gem 'rundeck' do
-  version '> 1.0.2'
+  version '>= 1.1.0'
 end


### PR DESCRIPTION
This depends on dblessing/rundeck-ruby#28 integration.