### PR TITLE
Fix one job case

### DIFF
--- a/providers/job.rb
+++ b/providers/job.rb
@@ -107,7 +107,7 @@ def find_job_id(client, project, name)
           fail "Several jobs exist with name #{name}, unable to choose" unless matching_jobs.size < 2
           matching_jobs.first
         when Hash # one job
-          jobs
+          jobs['name'] == name ? jobs : nil
         end
   job['id'] if job
 end


### PR DESCRIPTION
Previously, in one job project we case, we always update this one job,
whatever its name.
Now, we check the job name.