### PR TITLE
Added sensitivity flag to rundeck-config.properites template

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -43,6 +43,7 @@ end
 template ::File.join(node['rundeck_server']['confdir'], 'rundeck-config.properties') do
   source   'properties.erb'
   mode     '0644'
+  sansitive true
   notifies :restart, 'service[rundeckd]', :delayed
   variables(properties: node['rundeck_server']['rundeck-config.properties'])
 end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -43,7 +43,7 @@ end
 template ::File.join(node['rundeck_server']['confdir'], 'rundeck-config.properties') do
   source   'properties.erb'
   mode     '0644'
-  sansitive true
+  sensitive true
   notifies :restart, 'service[rundeckd]', :delayed
   variables(properties: node['rundeck_server']['rundeck-config.properties'])
 end


### PR DESCRIPTION
May contain sensitive information if using plaintext password for providers for Jasypt encryption plugin