### PR TITLE
Disable test kitchen run on pull request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ before_deploy:
 - openssl aes-256-cbc -K $encrypted_1e1bf3b45faf_key -iv $encrypted_1e1bf3b45faf_iv
   -in .travis/client.pem.enc -out .travis/client.pem -d
 before_install:
-- openssl aes-256-cbc -K $encrypted_5b96b54c695c_key -iv $encrypted_5b96b54c695c_iv
-  -in .travis/travis-ci.pem.enc -out ~/.ssh/id_rsa -d
+- '[ -n "$encrypted_5b96b54c695c_iv" ] && openssl aes-256-cbc -K $encrypted_5b96b54c695c_key
+  -iv $encrypted_5b96b54c695c_iv -in .travis/travis-ci.pem.enc -out ~/.ssh/id_rsa -d'
 env:
   global:
   - secure: GRVhcV8ERegECusJm4+kBSN+Ir9+xlkCLpHQVG3WUrAP5MBzI2hbu48WBje4pUABJ2JJUV5eVTE3CJiSgpscybplcHT82QWPRPwTZeQlVEEd/ocSWiE0j1ddxGbka/rie4O1CfZPjkg/XDR+GLvhtbUMSKiUw0mGG4LACsZ5b2M=

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ RSpec::Core::RakeTask.new(:rspec)
 
 
 desc 'Run kitchen tests'
-task :test_ec2 do
+task :test_kitchen do
   Kitchen.logger = Kitchen.default_file_logger
   @loader = Kitchen::Loader::YAML.new(project_config: './.kitchen.ec2.yml')
   config = Kitchen::Config.new(loader: @loader)
@@ -23,4 +23,7 @@ task :test_ec2 do
     threads.map(&:join)
   end
 end
-task default: [:foodcritic, :rspec, :test_ec2]
+
+tasks = [:foodcritic, :rspec]
+tasks << :test_kitchen if ENV['encrypted_5b96b54c695c_iv']
+task default: tasks


### PR DESCRIPTION
Travis build triggered by an external pull request should not fail anymore if encrypted environment variables are unavailable. Instead, the decryption and the rake task for test-kitchen are skipped.