### PR TITLE
encode percent sign in job config

### DIFF
--- a/providers/job.rb
+++ b/providers/job.rb
@@ -36,6 +36,8 @@ action :create do
     # yamlize update_job
     job_yaml = [updated_job].to_yaml.gsub(/^---\n/, '')
 
+    # encode % in job config
+    job_yaml = job_yaml.gsub(/\%/, '%25')
     # encode + in job config
     job_yaml = job_yaml.gsub(/\+/, '%2B')
     # encode & in job config


### PR DESCRIPTION
I had a problem with using something like `date -u +%Y-%m-%d-%H-%M` in a job definition's inline script.  This change fixed it for me.
