### PR TITLE
Don't restart on ACL policy changes

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -35,7 +35,6 @@ node['rundeck_server']['aclpolicy'].each do |policy, configuration|
     variables(conf: configuration)
     action   :create
     not_if   { configuration.nil? }
-    notifies :restart, 'service[rundeckd]', :delayed
   end
 end
 


### PR DESCRIPTION
Per Rundeck's documentation, ACL policy changes don't require a restart of the service: http://rundeck.org/docs/administration/access-control-policy.html#lifecycle