### PR TITLE
Update to fix Rundeck 2.7.x installation

### DIFF
--- a/.kitchen.ec2.yml
+++ b/.kitchen.ec2.yml
@@ -41,3 +41,4 @@ suites:
   - name: default
     run_list:
       - recipe[rundeck-server]
+      - recipe[rundeck-server::install_cli]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,21 +17,6 @@ suites:
   - name: server
     run_list:
       - recipe[rundeck-server]
-
-  - name: server-2.7.x
-    attributes:
-      rundeck_server:
-        jaas:
-          - module: 'org.eclipse.jetty.jaas.spi.PropertyFileLoginModule'
-            flag: 'required'
-            options:
-              debug: 'true'
-              file: '/etc/rundeck/realm.properties'
-        packages:
-          rundeck: '2.7.1-1.25.GA'
-          rundeck-config: '2.7.1-1.25.GA'
-    run_list:
-      - recipe[rundeck-server]
       - recipe[rundeck-server::install_cli]
 
   - name: job

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,7 +7,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.5.1
+  require_chef_omnibus: 12.15.19
 
 platforms:
   - name: centos-6.8

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -18,6 +18,22 @@ suites:
     run_list:
       - recipe[rundeck-server]
 
+  - name: server-2.7.x
+    attributes:
+      rundeck_server:
+        jaas:
+          - module: 'org.eclipse.jetty.jaas.spi.PropertyFileLoginModule'
+            flag: 'required'
+            options:
+              debug: 'true'
+              file: '/etc/rundeck/realm.properties'
+        packages:
+          rundeck: '2.7.1-1.25.GA'
+          rundeck-config: '2.7.1-1.25.GA'
+    run_list:
+      - recipe[rundeck-server]
+      - recipe[rundeck-server::install_cli]
+
   - name: job
     attributes:
       rundeck_server:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,7 @@
-TrailingCommaInLiteral:
-  EnforcedStyleForMultiline: comma
-TrailingCommaInArguments:
-  EnforcedStyleForMultiline: comma
-SpaceBeforeFirstArg:
-  Enabled: false
+AllCops:
+  Exclude:
+    - test/cookbooks/rundeck-test/attributes/**/*
+    - spec/spec_helper.rb
+
 LineLength:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,8 @@
-TrailingComma:
+TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
-SingleSpaceBeforeFirstArg:
+TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+SpaceBeforeFirstArg:
   Enabled: false
 LineLength:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+1.3.0
+-----
+
+    * Update to allow installation of Rundeck 2.7.x
+    * Add CLI installation recipe
+    * Fix a lot of rubocop warnings/cautions
+    * Update documentation
+
+1.2.0
+-----
+
+
 1.1.2 (2015-12-10)
 -----
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ gem 'fauxhai',    '>= 2.2'
 gem 'foodcritic', '>= 4.0'
 gem 'rake'
 
-# TODO Check why build is failing for rspec-mocks > 3.4.0
-gem 'rspec-mocks','= 3.4.0'
+# TODO: Check why build is failing for rspec-mocks > 3.4.0
+gem 'rspec-mocks', '= 3.4.0'
 
 gem 'test-kitchen'
 gem 'kitchen-vagrant'
@@ -16,7 +16,7 @@ gem 'kitchen-vagrant'
 gem 'rundeck', '>= 1.1.0'
 
 group :ec2 do
-  gem 'kitchen-ec2', :git => 'https://github.com/criteo-forks/kitchen-ec2.git', :branch => 'criteo'
+  gem 'kitchen-ec2', git: 'https://github.com/criteo-forks/kitchen-ec2.git', branch: 'criteo'
   gem 'winrm',      '~> 1.6'
   gem 'winrm-fs',   '~> 0.3'
 end

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Name | Description | Default
 * `node['rundeck_server']['jvm']['server']` |  |Defaults to `"true"`.
 * `node['rundeck_server']['threadcount']` | Quartz job threadCount. |Defaults to `"10"`.
 * `node['rundeck_server']['rundeck-config.properties']['loglevel.default']` |  |Defaults to `"INFO"`.
+* `node['rundeck_server']['rundeck-config.properties']['dataSource.url']` | Default database URL |Defaults to `jdbc:h2:file:~/grailsh2`.
 * `node['rundeck_server']['rundeck-config.properties']['rdeck.base']` |  |Defaults to `"node['rundeck_server']['basedir']"`.
 * `node['rundeck_server']['rundeck-config.properties']['rss.enabled']` |  |Defaults to `"false"`.
 * `node['rundeck_server']['rundeck-config.properties']['grails.serverURL']` |  |Defaults to `"http://localhost:4440"`.
@@ -78,11 +79,13 @@ Name | Description | Default
 * `node['rundeck_server']['yum']['baseurl']` |Rundeck yum resource parameter |Defaults to `"http://dl.bintray.com/rundeck/rundeck-rpm/"`
 * `node['rundeck_server']['yum']['gpgkey']` |Rundeck yum resource parameter |Defaults to `"http://rundeck.org/keys/BUILD-GPG-KEY-Rundeck.org.key"`
 * `node['rundeck_server']['yum']['action']` |Rundeck yum resource parameter |Defaults to `:create`
+* `node['rundeck_server']['cli']['config']` |Parameters to configure Rundeck CLI for Rundeck 2.7.x . See [documentation](https://github.com/rundeck/rundeck-cli/blob/master/docs/configuration.md)|Defaults to `{ RD_URL: 'http://localhost:4440' }`
 
 # Recipes
 
 * rundeck-server::install
 * rundeck-server::config
+* rundeck-server::install_cli - Installs the [Rundeck CLI](https://rundeck.github.io/rundeck-cli/) - Only use for Rundeck 2.7.x and above
 * [rundeck-server::default](#rundeck-serverdefault)
 
 ## rundeck-server::default

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Name | Description | Default
 * `node['rundeck_server']['yum']['gpgkey']` |Rundeck yum resource parameter |Defaults to `"http://rundeck.org/keys/BUILD-GPG-KEY-Rundeck.org.key"`
 * `node['rundeck_server']['yum']['action']` |Rundeck yum resource parameter |Defaults to `:create`
 * `node['rundeck_server']['cli']['config']` |Parameters to configure Rundeck CLI for Rundeck 2.7.x . See [documentation](https://github.com/rundeck/rundeck-cli/blob/master/docs/configuration.md)|Defaults to `{ RD_URL: 'http://localhost:4440' }`
+* `node['rundeck_server']['cli']['version']` |Allows to dictate version of Rundeck CLI to install|Defaults to 1.0.4-1
 
 # Recipes
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,6 @@ require 'foodcritic'
 FoodCritic::Rake::LintTask.new
 RSpec::Core::RakeTask.new(:rspec)
 
-
 desc 'Run kitchen tests'
 task :test_kitchen do
   Kitchen.logger = Kitchen.default_file_logger

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,8 +10,8 @@ default['java']['jdk_version'] = '8'
 
 # Version of Rundeck packages
 default['rundeck_server']['packages'] = {
-  'rundeck'        => '2.6.11-1.23.GA',
-  'rundeck-config' => '2.6.11-1.23.GA'
+  'rundeck'        => '2.7.1-1.25.GA',
+  'rundeck-config' => '2.7.1-1.25.GA'
 }
 
 # This depends on the package used
@@ -103,10 +103,11 @@ default['rundeck_server']['realm.properties']['admin'] = 'admin,user,admin,archi
 default['rundeck_server']['cli']['config'] = {
   RD_URL: 'http://localhost:4440'
 }
+default['rundeck_server']['cli']['version'] = '1.0.4-1'
 
 # <> The JAAS login configuration file with one entry and multiple modules may be generated from this attribute.
 default['rundeck_server']['jaas'] = [{
-  module:  'org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule',
+  module:  'org.eclipse.jetty.jaas.spi.PropertyFileLoginModule',
   flag:    'required',
   options: {
     debug: 'true',

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,7 +10,7 @@ default['java']['jdk_version'] = '7'
 # Version of Rundeck packages
 default['rundeck_server']['packages'] = {
   'rundeck'        => '2.6.11-1.23.GA',
-  'rundeck-config' => '2.6.11-1.23.GA',
+  'rundeck-config' => '2.6.11-1.23.GA'
 }
 
 # This depends on the package used
@@ -19,20 +19,20 @@ default['rundeck_server']['basedir'] = '/var/lib/rundeck'
 default['rundeck_server']['logdir']  = '/var/log/rundeck'
 default['rundeck_server']['datadir'] = '/var/rundeck'
 
-#<> Default security-role/role-name allowed to authenticate
+# <> Default security-role/role-name allowed to authenticate
 default['rundeck_server']['rolename'] = 'user'
 # see https://github.com/rundeck/rundeck/wiki/Faq#i-get-an-error-logging-in-http-error-403--reason-role for more information
 
-#<> session timeout in the UI (in minutes)
+# <> session timeout in the UI (in minutes)
 default['rundeck_server']['session_timeout'] = 30
 
-#<> Repository containing the rundeck package
+# <> Repository containing the rundeck package
 default['rundeck_server']['repo'] = 'http://dl.bintray.com/rundeck/rundeck-rpm/'
 
-#<> Plugin list to install. Type is { 'pluginname' => { 'url' => URL } }
+# <> Plugin list to install. Type is { 'pluginname' => { 'url' => URL } }
 default['rundeck_server']['plugins']['winrm']['url'] = 'https://github.com/rundeck-plugins/rundeck-winrm-plugin/releases/download/v1.2/rundeck-winrm-plugin-1.2.jar'
 
-#JVM configuration
+# JVM configuration
 #
 # Option mapping rules
 # ['key'] = 'string' maps to -key=string
@@ -45,14 +45,14 @@ default['rundeck_server']['jvm']['Drundeck.server.configDir']        = node['run
 default['rundeck_server']['jvm']['Drundeck.server.serverDir']        = node['rundeck_server']['basedir']
 # Default is the directory containing the launcher jar
 default['rundeck_server']['jvm']['Drdeck.base']                      = node['rundeck_server']['basedir']
-#<> Address/hostname to listen on
+# <> Address/hostname to listen on
 default['rundeck_server']['jvm']['Dserver.http.host']                = '0.0.0.0'
-#<> The HTTP port to use for the server
+# <> The HTTP port to use for the server
 default['rundeck_server']['jvm']['Dserver.http.port']                = '4440'
-#<> The HTTPS port to use or the server
+# <> The HTTPS port to use or the server
 default['rundeck_server']['jvm']['Dserver.https.port']               = '4443'
 default['rundeck_server']['jvm']['Djava.io.tmpdir']                  = ::File.join('tmp', 'rundeck')
-#<> Path to server datastore dir
+# <> Path to server datastore dir
 default['rundeck_server']['jvm']['Dserver.datastore.path']           = ::File.join(node['rundeck_server']['basedir'], 'data')
 default['rundeck_server']['jvm']['Djava.security.auth.login.config'] = ::File.join(node['rundeck_server']['confdir'], 'jaas-loginmodule.conf')
 default['rundeck_server']['jvm']['Drdeck.projects']                  = ::File.join(node['rundeck_server']['datadir'], 'projects')
@@ -64,7 +64,7 @@ default['rundeck_server']['jvm']['Xmx1024m']       = true
 default['rundeck_server']['jvm']['Xms256m']        = true
 default['rundeck_server']['jvm']['server']         = true
 
-#<> Quartz job threadCount
+# <> Quartz job threadCount
 default['rundeck_server']['threadcount'] = 10
 # see http://rundeck.org/docs/administration/tuning-rundeck.html#quartz-job-threadcount
 
@@ -93,46 +93,46 @@ default['rundeck_server']['rundeck-config.framework']['framework.ssh.user']     
 default['rundeck_server']['rundeck-config.framework']['framework.ssh.timeout']      = 0
 
 # realm.properties users
-default['rundeck_server']['realm.properties']['admin'] = "admin,user,admin,architect,deploy,build"
+default['rundeck_server']['realm.properties']['admin'] = 'admin,user,admin,architect,deploy,build'
 
-#<> The JAAS login configuration file with one entry and multiple modules may be generated from this attribute.
+# <> The JAAS login configuration file with one entry and multiple modules may be generated from this attribute.
 default['rundeck_server']['jaas'] = [{
   module:  'org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule',
   flag:    'required',
   options: {
     debug: 'true',
-    file:  '/etc/rundeck/realm.properties',
-  },
+    file:  '/etc/rundeck/realm.properties'
+  }
 }]
 # see http://docs.oracle.com/javase/8/docs/technotes/guides/security/jgss/tutorials/LoginConfigFile.html
 
-#<> The admin ACL policy in YAML is generated from this attribute.
+# <> The admin ACL policy in YAML is generated from this attribute.
 default['rundeck_server']['aclpolicy']['admin'] = [{
   description: 'Admin, all access.',
   context: {
-    project: '.*',
+    project: '.*'
   },
   for: {
     resource: [{ allow: '*' }],
     adhoc:    [{ allow: '*' }],
     job:      [{ allow: '*' }],
-    node:     [{ allow: '*' }],
+    node:     [{ allow: '*' }]
   },
   by: {
-    group:    ['admin'],
-  },
+    group:    ['admin']
+  }
 }, {
   description: 'Admin, all access.',
   context: {
-    application: 'rundeck',
+    application: 'rundeck'
   },
   for: {
     resource: [{ allow: '*' }],
     project:  [{ allow: '*' }],
-    storage:  [{ allow: '*' }],
+    storage:  [{ allow: '*' }]
   },
   by: {
-    group:    ['admin'],
-  },
+    group:    ['admin']
+  }
 }]
 # Check out the docs at: http://rundeck.org/docs/man5/aclpolicy.html

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,9 +3,10 @@
 # Attributes: default
 #
 
-# Java 7 is needed for RunDeck 2.5.0 and above
+# Java 8 is needed for RunDeck 2.7.x, Rundeck author suggests Java 7 and below
+# is now deprecated in terms of support
 default['rundeck_server']['install_java'] = true
-default['java']['jdk_version'] = '7'
+default['java']['jdk_version'] = '8'
 
 # Version of Rundeck packages
 default['rundeck_server']['packages'] = {
@@ -73,6 +74,9 @@ default['rundeck_server']['rundeck-config.properties']['loglevel.default'] = 'IN
 default['rundeck_server']['rundeck-config.properties']['rdeck.base']       = node['rundeck_server']['basedir']
 default['rundeck_server']['rundeck-config.properties']['rss.enabled']      = false
 default['rundeck_server']['rundeck-config.properties']['grails.serverURL'] = 'http://localhost:4440'
+# see http://www.h2database.com/html/changelog.html (Starting with Version 1.4.177 Beta)
+# Fixes implicit relative path usage
+default['rundeck_server']['rundeck-config.properties']['dataSource.url']   = 'jdbc:h2:file:~/grailsh2'
 
 # rundeck-config.framework configuration
 default['rundeck_server']['rundeck-config.framework']['framework.server.name']      = 'localhost'
@@ -94,6 +98,11 @@ default['rundeck_server']['rundeck-config.framework']['framework.ssh.timeout']  
 
 # realm.properties users
 default['rundeck_server']['realm.properties']['admin'] = 'admin,user,admin,architect,deploy,build'
+
+# See: https://github.com/rundeck/rundeck-cli/blob/master/docs/configuration.md
+default['rundeck_server']['cli']['config'] = {
+  RD_URL: 'http://localhost:4440'
+}
 
 # <> The JAAS login configuration file with one entry and multiple modules may be generated from this attribute.
 default['rundeck_server']['jaas'] = [{

--- a/attributes/log4j.rb
+++ b/attributes/log4j.rb
@@ -11,8 +11,8 @@ default['rundeck_server']['log4j.properties']['log4j.rootLogger'] = 'warn, stdou
 
 default['rundeck_server']['log4j.properties']['log4j.com.dtolabs.rundeck.core'] = 'INFO, cmd-logger'
 
-#log4j.logger.org.codehaus.groovy.grails.plugins.quartz'] = 'debug,stdout'
-#log4j.additivity.org.codehaus.groovy.grails.plugins.quartz'] = 'false'
+# log4j.logger.org.codehaus.groovy.grails.plugins.quartz'] = 'debug,stdout'
+# log4j.additivity.org.codehaus.groovy.grails.plugins.quartz'] = 'false'
 
 # Enable audit logging
 default['rundeck_server']['log4j.properties']['log4j.logger.com.dtolabs.rundeck.core.authorization'] = 'info, audit'
@@ -44,12 +44,12 @@ default['rundeck_server']['log4j.properties']['log4j.additivity.org.rundeck.stor
 
 # Enable this logger to log Hibernate output
 # handy to see its database interaction activity
-#log4j.logger.org.hibernate'] = 'debug,stdout'
-#log4j.additivity.org.hibernate'] = 'false'
+# log4j.logger.org.hibernate'] = 'debug,stdout'
+# log4j.additivity.org.hibernate'] = 'false'
 
 # Enable this logger to see what Spring does, occasionally useful
-#log4j.logger.org.springframework'] = 'info,stdout '
-#log4j.additivity.org.springframework'] = 'false'
+# log4j.logger.org.springframework'] = 'info,stdout '
+# log4j.additivity.org.springframework'] = 'false'
 
 # This logger covers all of Grails' internals
 # Enable to see whats going on underneath.
@@ -69,7 +69,6 @@ default['rundeck_server']['log4j.properties']['log4j.additivity.org.codehaus.gro
 # This logger is for Grails' public APIs within the grails. package
 default['rundeck_server']['log4j.properties']['log4j.logger.grails'] = 'info,stdout, server-logger'
 default['rundeck_server']['log4j.properties']['log4j.additivity.grails'] = 'false        '
-
 
 ####################################################################################################
 #

--- a/attributes/repo.rb
+++ b/attributes/repo.rb
@@ -1,4 +1,4 @@
-default['rundeck_server']['yum']['description'] = "Rundeck Official Repo"
+default['rundeck_server']['yum']['description'] = 'Rundeck Official Repo'
 default['rundeck_server']['yum']['gpgcheck']    = true
 default['rundeck_server']['yum']['enabled']     = true
 default['rundeck_server']['yum']['baseurl']     = 'http://dl.bintray.com/rundeck/rundeck-rpm/'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'r.veznaver@criteo.com'
 license          'Apache License 2.0'
 description      'Installs rundeck and configure as needed'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.0'
+version          '1.3.0'
 supports         'centos'
 
 depends          'yum'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,3 +12,6 @@ depends          'java'
 
 suggests         'rundeck-bridge'
 suggests         'rundeck-node'
+
+source_url 'https://github.com/criteo-cookbooks/rundeck-server'
+issues_url 'https://github.com/criteo-cookbooks/rundeck-server/issues'

--- a/providers/job.rb
+++ b/providers/job.rb
@@ -89,7 +89,7 @@ end
 # Hash equality with a clearer diff
 def equal_with_diff(h1, h2)
   if h1.class != h2.class
-    Chef::Log.info("Not the same class!")
+    Chef::Log.info('Not the same class!')
     Chef::Log.info("before: #{h1.class}")
     Chef::Log.info("after:  #{h2.class}")
     return false
@@ -104,12 +104,10 @@ def equal_with_diff(h1, h2)
       h1[k] == h2[k]
     end
   when Array
-    if h1.size != h2.size
-      Chef::Log.info("Not the same size!")
-    end
+    Chef::Log.info('Not the same size!') if h1.size != h2.size
     h1.zip(h2).all? do |el|
       if el[0] != el[1]
-        Chef::Log.info("Difference for array element")
+        Chef::Log.info('Difference for array element')
         equal_with_diff(el[0], el[1])
         Chef::Log.info('array before: ' + h1.to_s)
         Chef::Log.info('array after: ' + h2.to_s)
@@ -118,8 +116,8 @@ def equal_with_diff(h1, h2)
     end
   else
     if h1 != h2
-      Chef::Log.info("before: "+ h1.to_s)
-      Chef::Log.info("after: "+ h2.to_s)
+      Chef::Log.info('before: ' + h1.to_s)
+      Chef::Log.info('after: ' + h2.to_s)
     end
     h1 == h2
   end

--- a/providers/project.rb
+++ b/providers/project.rb
@@ -11,7 +11,7 @@ action :create do
   end
 
   properties = {
-    'project.name' => new_resource.name,
+    'project.name' => new_resource.name
   }
 
   executor = new_resource.executor
@@ -23,8 +23,8 @@ action :create do
         provider: 'jsch-ssh',
         config: {
           'ssh-authentication'  => 'privateKey',
-          'ssh-keypath'         => "#{node['rundeck_server']['basedir']}/.ssh/id_rsa",
-        },
+          'ssh-keypath'         => "#{node['rundeck_server']['basedir']}/.ssh/id_rsa"
+        }
       }
     when :winrm
       fail 'WinRM template not yet supported'
@@ -35,7 +35,7 @@ action :create do
 
   properties['service.NodeExecutor.default.provider'] = executor[:provider] || executor['provider']
   (executor[:config] || executor['config']).each do |key, value|
-    properties["project.#{key}"]  = value
+    properties["project.#{key}"] = value
   end
 
   new_resource.sources.each_with_index do |source, i|

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -21,7 +21,7 @@ template 'rundeck-jaas' do
   path     "#{node['rundeck_server']['confdir']}/jaas-loginmodule.conf"
   source   'jaas-loginmodule.conf.erb'
   variables(conf: node['rundeck_server']['jaas'])
-  action   :create
+  action :create
   sensitive true
   not_if   { node['rundeck_server']['jaas'].nil? }
   notifies :restart, 'service[rundeckd]', :delayed
@@ -63,7 +63,7 @@ web_xml = "#{node['rundeck_server']['basedir']}/exp/webapp/WEB-INF/web.xml"
 
 web_xml_update = {
   'web-app/security-role/role-name'        => node['rundeck_server']['rolename'],
-  'web-app/session-config/session-timeout' => node['rundeck_server']['session_timeout'],
+  'web-app/session-config/session-timeout' => node['rundeck_server']['session_timeout']
 }
 
 ruby_block 'web-xml-update' do # ~FC022

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -9,18 +9,17 @@ It also install rundeck gem to allow to configure rundeck via ruby
 #>
 =end
 
-
 include_recipe 'rundeck-server::install'
 include_recipe 'rundeck-server::config'
 
 # Define service
 service 'rundeckd' do
   supports status: true, restart: true
-  action   [:enable, :start]
+  action [:enable, :start]
 end
 
 # Install rundeck gem for API communication
 chef_gem 'rundeck' do
-  version      '>= 1.1.0'
+  version '>= 1.1.0'
   compile_time false
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -15,7 +15,7 @@ yum_repository 'rundeck' do
 end
 
 # Install Rundeck packages
-package 'Rundeck Packages'  do
+package 'Rundeck Packages' do
   package_name    node['rundeck_server']['packages'].keys
   version         node['rundeck_server']['packages'].values
   action          :install

--- a/recipes/install_cli.rb
+++ b/recipes/install_cli.rb
@@ -5,7 +5,9 @@
 # Note: This must be Java 8 or greater
 include_recipe 'java' if node['rundeck_server']['install_java']
 
-package 'rundeck-cli'
+package 'rundeck-cli' do
+	version node['rundeck_server']['cli']['version']
+end
 
 directory ::File.join(node['rundeck_server']['basedir'], '.rd') do
   owner 'rundeck'

--- a/recipes/install_cli.rb
+++ b/recipes/install_cli.rb
@@ -2,10 +2,7 @@
 # Recipe:   install_cli
 # Description: This should be ran if using Rundeck 7.x+
 # See: http://rundeck.org/docs/upgrading/index.html#cli-tools-are-gone
-#
-
 # Note: This must be Java 8 or greater
-# See:
 include_recipe 'java' if node['rundeck_server']['install_java']
 
 package 'rundeck-cli'

--- a/recipes/install_cli.rb
+++ b/recipes/install_cli.rb
@@ -6,7 +6,7 @@
 include_recipe 'java' if node['rundeck_server']['install_java']
 
 package 'rundeck-cli' do
-	version node['rundeck_server']['cli']['version']
+  version node['rundeck_server']['cli']['version']
 end
 
 directory ::File.join(node['rundeck_server']['basedir'], '.rd') do
@@ -15,10 +15,10 @@ directory ::File.join(node['rundeck_server']['basedir'], '.rd') do
 end
 
 template 'rd.conf' do
-  path     ::File.join(node['rundeck_server']['basedir'], '.rd', 'rd.conf')
+  path ::File.join(node['rundeck_server']['basedir'], '.rd', 'rd.conf')
   variables(properties: node['rundeck_server']['cli']['config'])
   action :create
   sensitive true
-	owner 'rundeck'
+  owner 'rundeck'
   group 'rundeck'
 end

--- a/recipes/install_cli.rb
+++ b/recipes/install_cli.rb
@@ -1,0 +1,25 @@
+# Cookbook: rundeck-server
+# Recipe:   install_cli
+# Description: This should be ran if using Rundeck 7.x+
+# See: http://rundeck.org/docs/upgrading/index.html#cli-tools-are-gone
+#
+
+# Note: This must be Java 8 or greater
+# See:
+include_recipe 'java' if node['rundeck_server']['install_java']
+
+package 'rundeck-cli'
+
+directory ::File.join(node['rundeck_server']['basedir'], '.rd') do
+  owner 'rundeck'
+  group 'rundeck'
+end
+
+template 'rd.conf' do
+  path     ::File.join(node['rundeck_server']['basedir'], '.rd', 'rd.conf')
+  variables(properties: node['rundeck_server']['cli']['config'])
+  action :create
+  sensitive true
+	owner 'rundeck'
+  group 'rundeck'
+end

--- a/resources/job.rb
+++ b/resources/job.rb
@@ -20,7 +20,7 @@ Manage rundeck jobs through rundeck api
         },
         nodefilters: { dispatch: { threadcount: 10 } },
         filter: '.*'
-      }) 
+      })
     end
 #>
 =end
@@ -28,13 +28,13 @@ Manage rundeck jobs through rundeck api
 actions :create, :delete
 default_action :create
 
-#<> @attribute name Name of the job, will be used to identify the job when interacting with rundeck.
+# <> @attribute name Name of the job, will be used to identify the job when interacting with rundeck.
 attribute :name,      name_attribute:  true, regex: /^[-_+.a-zA-Z0-9() ]+$/
-#<> @attribute project Project in which the job will be defined
+# <> @attribute project Project in which the job will be defined
 attribute :project,   kind_of: String, required: true
-#<> @attribute config Job configuration, it is a hash version of yaml output from rundeck api
+# <> @attribute config Job configuration, it is a hash version of yaml output from rundeck api
 attribute :config,    kind_of: Hash,   default: {}
-#<> @attribute endpoint
+# <> @attribute endpoint
 attribute :endpoint,  kind_of: String, default: 'https://localhost'
-#<> @attribute api_token Token used to interact with the api. See rundeck documentation to generate a token.
+# <> @attribute api_token Token used to interact with the api. See rundeck documentation to generate a token.
 attribute :api_token, kind_of: String, required: true

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -23,10 +23,10 @@ project provider configures a rundeck project
         'type'            => 'url',
         'config.url'      => "http://url,
         'config.timeout'  => 30,
-        'config.cache'    => true,
+        'config.cache'    => true
       }])
      end
-     
+
      # ssh example
      rundeck_server_project 'linux_servers' do
        executor 'ssh'
@@ -34,7 +34,7 @@ project provider configures a rundeck project
         'type'            => 'url',
         'config.url'      => "http://chef-bridge/linux,
         'config.timeout'  => 30,
-        'config.cache'    => true,
+        'config.cache'    => true
       }])
      end
 #>
@@ -43,13 +43,13 @@ project provider configures a rundeck project
 actions :create, :delete
 default_action :create
 
-#<> @attribute name Name of the project
+# <> @attribute name Name of the project
 attribute :name,
           kind_of: String,
           name_attribute: true,
           regex: /^[-_+.a-zA-Z0-9]+$/
 
-#<> @attribute executor Executor name + configuration. Could be a plain string (ssh) or complex hash configuration.
+# <> @attribute executor Executor name + configuration. Could be a plain string (ssh) or complex hash configuration.
 attribute :executor,
           kind_of: [Symbol, Hash],
           default: :ssh,
@@ -59,10 +59,10 @@ attribute :executor,
             end,
             must_contain_config: lambda do |executor|
               executor.is_a?(Symbol) || (executor['config'] || executor[:config]).is_a?(Hash)
-            end,
+            end
           }
 
-#<> @attribute sources List of node sources
+# <> @attribute sources List of node sources
 attribute :sources,
           kind_of: Array,
           required: true,
@@ -72,7 +72,7 @@ attribute :sources,
             end,
             must_contain_type: lambda do |sources|
               sources.all? { |source| source['type'] || source[:type] }
-            end,
+            end
           }
 
 attribute :cookbook,

--- a/spec/recipes/lwrp_spec.rb
+++ b/spec/recipes/lwrp_spec.rb
@@ -5,7 +5,7 @@ describe 'rundeck-test::project' do
 
   let(:chef_run) do
     ChefSpec::SoloRunner.new(
-      step_into: ['rundeck_server_project'],
+      step_into: ['rundeck_server_project']
     ).converge(described_recipe)
   end
 
@@ -18,7 +18,7 @@ end
 describe 'rundeck-test::job' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new(
-      step_into: ['rundeck_server_job'],
+      step_into: ['rundeck_server_job']
     ).converge(described_recipe)
   end
 
@@ -51,7 +51,7 @@ describe 'rundeck-test::job' do
       expect(client).to receive(:import_jobs).with(
         "- description: ''\n  loglevel: INFO\n  sequence:\n    commands:\n    - exec: a command\n  name: test-job\n  project: project\n  uuid: abcde\n",
         'yaml',
-        kind_of(Hash),
+        kind_of(Hash)
       ) { response }
       chef_run # evaluate chef_run
     end

--- a/spec/recipes/server_spec.rb
+++ b/spec/recipes/server_spec.rb
@@ -21,7 +21,7 @@ describe 'rundeck-server' do
 
   it 'check default template content' do
     expect(chef_run).to render_file('rundeck-jaas')
-      .with_content('org.eclipse.jetty.plus.jaas.spi.PropertyFileLoginModule')
+      .with_content('org.eclipse.jetty.jaas.spi.PropertyFileLoginModule')
   end
 
   it 'simple default admin aclpolicy yaml content' do

--- a/templates/default/profile.erb
+++ b/templates/default/profile.erb
@@ -38,3 +38,7 @@ then
 fi
 
 umask 002
+
+# https://github.com/rundeck/rundeck/issues/2237
+rundeckd="${JAVA_HOME:-/usr}/bin/java ${RDECK_JVM} -cp ${BOOTSTRAP_CP} com.dtolabs.rundeck.RunServer /var/lib/rundeck ${RDECK_HTTP_PORT}"
+export rundeckd

--- a/templates/default/rd.conf.erb
+++ b/templates/default/rd.conf.erb
@@ -1,0 +1,3 @@
+<% @properties.sort.each do |key, value| %>
+export <%= key %>=<%= value.to_s if value.is_a? String %>
+<% end %>

--- a/test/cookbooks/rundeck-test/attributes/default.rb
+++ b/test/cookbooks/rundeck-test/attributes/default.rb
@@ -13,14 +13,14 @@ job_template = {
     'strategy'  => 'node-first',
     'commands'  => [{
       'exec'        => 'uname -a',
-      'description' => 'Output uname',
+      'description' => 'Output uname'
     }, {
       'exec'        => 'mkdir /tmp/test',
-      'description' => 'Create a test directory',
+      'description' => 'Create a test directory'
     }, {
       'exec'        => 'touch /tmp/test/${option.version}',
-      'description' => 'Create version file',
-    }],
+      'description' => 'Create version file'
+    }]
   },
   'nodefilters' => {
     'filter'   => 'location: ${option.location}',
@@ -28,21 +28,21 @@ job_template = {
       'threadcount'       => 30,
       'keepgoing'         => true,
       'excludePrecedence' => true,
-      'rankOrder'         => 'ascending',
-    },
+      'rankOrder'         => 'ascending'
+    }
   },
   'timeout' => '1h',
   'options' =>  {
     'location' => {
-      'required' => true,
+      'required' => true
     },
     'version' => {
-      'required' => true,
+      'required' => true
     },
     'environment' => {
-      'required' => true,
-    },
-  },
+      'required' => true
+    }
+  }
 }
 
 # Release using one thread
@@ -66,7 +66,7 @@ Total maximum number of threads set to 100.\n",
   'sequence' => {
     'keepgoing' => true,
     'strategy'  => 'parallel',
-    'commands'  => [], # This is filled automatically by the loops below
+    'commands'  => [] # This is filled automatically by the loops below
   },
   'nodefilters' => {
     'filter'   => 'tags: service',
@@ -74,15 +74,15 @@ Total maximum number of threads set to 100.\n",
       'threadcount'       => 90,
       'keepgoing'         => true,
       'excludePrecedence' => true,
-      'rankOrder'         => 'ascending',
-    },
+      'rankOrder'         => 'ascending'
+    }
   },
   'options' => {
     'version' => {
       'required'    => true,
-      'description' => 'The version to release (upgrade or downgrade).',
-    },
-  },
+      'description' => 'The version to release (upgrade or downgrade).'
+    }
+  }
 }
 
 # Host release wrapper jobs
@@ -99,18 +99,18 @@ environments.each do |environment|
         'jobref' => {
           'group' => 'Test',
           'name'  => 'Release (parallel)',
-          'args'  =>  "-location #{location} -version ${option.version} -environment #{environment}",
+          'args'  =>  "-location #{location} -version ${option.version} -environment #{environment}"
         },
-        'description' => "Parallel rollout in #{location}",
+        'description' => "Parallel rollout in #{location}"
       }
     else
       step = {
         'jobref' => {
           'group' => 'Test',
           'name'  => 'Release (single)',
-          'args'  =>  "-location #{location} -version ${option.version} -environment #{environment}",
+          'args'  =>  "-location #{location} -version ${option.version} -environment #{environment}"
         },
-        'description' => "Single rollout in #{location}",
+        'description' => "Single rollout in #{location}"
       }
     end
     default['rundeck_test']['jobs']['Test']["Release (#{environment})"]['sequence']['commands'].push(step)

--- a/test/cookbooks/rundeck-test/recipes/default.rb
+++ b/test/cookbooks/rundeck-test/recipes/default.rb
@@ -15,8 +15,8 @@ rundeck_server_project 'dummy-project' do
   sources [
     { 'type'           => 'url',
       'config.url'     => 'http://localhost:9980/',
-      'config.timeout' => 30,
-    },
+      'config.timeout' => 30
+    }
   ]
 end
 
@@ -36,8 +36,8 @@ rundeck_server_job 'dummy-job' do
       keepgoing: false,
       strategy:  'node-first',
       commands: [
-        exec: 'Dummy command',
-      ],
+        exec: 'Dummy command'
+      ]
     })
   only_if 'curl --silent --fail --insecure http://localhost:4440'
 end
@@ -48,8 +48,8 @@ rundeck_server_project 'Test' do
   sources [
     { 'type'           => 'url',
       'config.url'     => 'http://localhost:9980/',
-      'config.timeout' => 30,
-    },
+      'config.timeout' => 30
+    }
   ]
 end
 

--- a/test/cookbooks/rundeck-test/recipes/job.rb
+++ b/test/cookbooks/rundeck-test/recipes/job.rb
@@ -6,7 +6,7 @@ rundeck_server_job 'test-job' do
     loglevel: 'INFO',
     sequence: {
       commands: [
-        exec: 'a command',
-      ],
+        exec: 'a command'
+      ]
     })
 end

--- a/test/cookbooks/rundeck-test/recipes/project.rb
+++ b/test/cookbooks/rundeck-test/recipes/project.rb
@@ -5,8 +5,8 @@ rundeck_server_project 'test-project-ssh' do
   sources [
     { 'type'           => 'url',
       'config.url'     => 'http://chefserver_bridge:9980/',
-      'config.timeout' => 30,
-    },
+      'config.timeout' => 30
+    }
   ]
 end
 
@@ -15,13 +15,13 @@ rundeck_server_project 'test-project-custom' do
     provider: 'overthere-winrm',
     config: {
       'winrm-auth-type' => 'kerberos',
-      'winrm-protocol'  => 'https',
-    },
+      'winrm-protocol'  => 'https'
+    }
   )
   sources [
     { 'type'           => 'url',
       'config.url'     => 'http://chefserver_bridge:9980/',
-      'config.timeout' => 30,
-    },
+      'config.timeout' => 30
+    }
   ]
 end


### PR DESCRIPTION
https://github.com/criteo-cookbooks/rundeck-server/issues/43

- Added Test Kitchen suite for Rundeck 2.7.x
- Updated Java installation to default to version 8
- Added Rundeck CLI installation recipe
- Added attribute to fix H2 installation/execution
- Added attributes to properly configure Rundeck 2.7.x CLI
- Added documentation 
- Fixes some Rubocop warnings
- Version bump
- Update changelog
- Some foodcritic fixes
- Updated default installation version in attributes to 2.7.x
