### PR TITLE
Fix syntax errors with ruby 2.4

### DIFF
--- a/resources/project.rb
+++ b/resources/project.rb
@@ -53,27 +53,27 @@ attribute :name,
 attribute :executor,
           kind_of: [Symbol, Hash],
           default: :ssh,
-          callbacks: {
+          callbacks: ({
             must_contain_provider: lambda do |executor|
               executor.is_a?(Symbol) || !executor['provider'].nil? || !executor[:provider].nil?
             end,
             must_contain_config: lambda do |executor|
               executor.is_a?(Symbol) || (executor['config'] || executor[:config]).is_a?(Hash)
             end
-          }
+          })
 
 # <> @attribute sources List of node sources
 attribute :sources,
           kind_of: Array,
           required: true,
-          callbacks: {
+          callbacks: ({
             must_be_an_array_of_hashes: lambda do |sources|
               sources.all? { |source| source.is_a?(Hash) }
             end,
             must_contain_type: lambda do |sources|
               sources.all? { |source| source['type'] || source[:type] }
             end
-          }
+          })
 
 attribute :cookbook,
           kind_of: String,


### PR DESCRIPTION
Hello,

We found several syntax errors regarding the project resource provider (we are using ruby 2.4) and we were unable to automatically upload the latest released version of the cookbook to the chef-server using berkshelf.

`E, [2017-03-07T14:08:54.516303 #10359] ERROR -- : Cookbook file .berkshelf/cookbooks/rundeck-server-1.3.2/resources/project.rb has a ruby syntax error:
E, [2017-03-07T14:08:54.517297 #10359] ERROR -- : Ridley::Errors::CookbookSyntaxError: Invalid ruby files in cookbook: rundeck-server (1.3.2).`

Thanks ! 