### PR TITLE
Select only matching job name

### DIFF
--- a/providers/job.rb
+++ b/providers/job.rb
@@ -81,7 +81,7 @@ end
 def get_job(client, project, name)
   require 'yaml'
   # export the job in YAML
-  job = client.export_jobs(project, 'yaml', opts.merge(query: { 'jobFilter' => name }))
+  job = client.export_jobs(project, 'yaml', opts.merge(query: { 'jobExactFilter' => name }))
   # return the parsed YAML
   YAML.load(job).first
 end


### PR DESCRIPTION
jobFilter would return any job whose name matches the operand.
jobExactFilter guarantees to return only the right job.

Change-Id: Idab4a4b3fd9d5a49065a8d44678783225f42bdac