### PR TITLE
Add a switch in the installation curl check to disregard SSL certificate verification due to self-signed certificates

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@ end
 
 
 execute 'ensure api is up' do
-  command "curl -s -f #{node['rundeck_server']['rundeck-config.framework']['framework.server.url']}"
+  command "curl -k -s -f #{node['rundeck_server']['rundeck-config.framework']['framework.server.url']}"
   retries 10
   retry_delay 30
 end


### PR DESCRIPTION
The installation job fails if it's an HTTPS endpoint and the SSL certificates provided are self-signed. Having self signed certs should be fine for testing and this should not fail if such is the case.