### PR TITLE
config.rb: Stop restarting Rundeck when updating plugins

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -12,7 +12,6 @@ unless node['rundeck_server']['plugins'].nil?
       mode     '0644'
       checksum source['checksum'] if source['checksum']
       backup   false
-      notifies :restart, 'service[rundeckd]', :delayed
     end
   end
 end

--- a/resources/job.rb
+++ b/resources/job.rb
@@ -28,13 +28,13 @@ Manage rundeck jobs through rundeck api
 # <> @property name Name of the job, will be used to identify the job when interacting with rundeck.
 property :job_name,      name_property:  true, regex: /^[-_+.a-zA-Z0-9() ]+$/
 # <> @property project Project in which the job will be defined
-property :project,   kind_of: String, required: true
+property :project,   String, required: true
 # <> @property config Job configuration, it is a hash version of yaml output from rundeck api
-property :config,    kind_of: Hash,   default: {}
+property :config,    Hash,   default: {}
 # <> @property endpoint
-property :endpoint,  kind_of: String, default: 'https://localhost'
+property :endpoint,  String, default: 'https://localhost'
 # <> @property api_token Token used to interact with the api. See rundeck documentation to generate a token.
-property :api_token, kind_of: String, required: true
+property :api_token, String, required: true
 
 def job_group(new_resource)
   new_resource.config['group'] || new_resource.config[:group]

--- a/resources/key.rb
+++ b/resources/key.rb
@@ -18,15 +18,15 @@ Manage rundeck key storage through rundeck api
 =end
 
 # <> @property path to key
-property :key,    kind_of: String, name_property:  true
+property :key,       String, name_property:  true
 # <> @property type of key. Can be 'private', 'public'
-property :type,     kind_of: Symbol, required: true, default: :public, equal_to: [:public, :private]
+property :type,      Symbol, required: true, default: :public, equal_to: [:public, :private]
 # <> @property key data
-property :content,    kind_of: String, required: false
+property :content,   String, required: false
 # <> @property endpoint
-property :endpoint,  kind_of: String, default: 'http://127.0.0.1:4440'
+property :endpoint,  String, default: 'http://127.0.0.1:4440'
 # <> @property api_token Token used to interact with the api. See rundeck documentation to generate a token.
-property :api_token, kind_of: String, required: true
+property :api_token, String, required: true
 
 action :create do
   require 'rundeck'

--- a/resources/project.rb
+++ b/resources/project.rb
@@ -65,13 +65,13 @@ project provider configures a rundeck project
 
 # <> @property name Name of the project
 property :project_name,
-          kind_of: String,
+          String,
           name_property: true,
           regex: /^[-_+.a-zA-Z0-9]+$/
 
 # <> @property executor Executor name + configuration. Could be a plain string (ssh) or complex hash configuration.
 property :executor,
-          kind_of: [Symbol, Hash],
+          [Symbol, Hash],
           default: :ssh,
           callbacks: ({
             must_contain_provider: lambda do |executor|
@@ -84,23 +84,23 @@ property :executor,
 
 # <> @property scm-import setting of the project
 property :scm_import,
-          kind_of: Hash,
+          Hash,
           required: false
 
 # <> @property scm-export setting of the project
 property :scm_export,
-          kind_of: Hash,
+          Hash,
           required: false
 
 # <> @property nodes setting of the project
 property :nodes,
-          kind_of: Array,
+          Array,
           required: false,
           default: []
 
 # <> @property sources List of node sources
 property :sources,
-          kind_of: Array,
+          Array,
           required: true,
           callbacks: ({
             must_be_an_array_of_hashes: lambda do |sources|
@@ -113,12 +113,12 @@ property :sources,
 
 # <> @property properties Hash of project properties
 property :properties,
-          kind_of: Hash,
+          Hash,
           required: false,
           default: {}
 
 property :cookbook,
-          kind_of: String,
+          String,
           default: 'rundeck-server'
 
 action :create do

--- a/spec/recipes/server_spec.rb
+++ b/spec/recipes/server_spec.rb
@@ -52,9 +52,9 @@ describe 'rundeck-server' do
 
   let(:chef_run) do
     ChefSpec::SoloRunner.new do |node|
-      node.set['rundeck_server']['plugins']['winrm']['checksum'] =
+      node.normal['rundeck_server']['plugins']['winrm']['checksum'] =
         '54500ae1db500f7be2e0468d6f464c1f7f28c5aa4c7c2e7f0cb3a5cfa0386824'
-      node.set['rundeck_server']['jvm']['Xmx1024m'] = false
+      node.normal['rundeck_server']['jvm']['Xmx1024m'] = false
     end.converge(described_recipe)
   end
 


### PR DESCRIPTION
As per documentation, Rundeck does not need to get restarted when
plugins are installed, updated, or removed.

Restarting Rundeck makes it kill the running jobs without notice,
which is undesirable.